### PR TITLE
exp6 popped back to index & exp8-old link fixed

### DIFF
--- a/src/lab/List of experiments.html
+++ b/src/lab/List of experiments.html
@@ -116,9 +116,9 @@
 <li>
 <a href="exp5/Introduction.html?domain=Computer Science&lab=Computational Linguistics Lab">Dictionary Generation</a>
 </li>
-<!--<li>
-	      <a href="exp6/Introduction.html?domain=Computer Science&lab=Computational Linguistics Lab">Word Sense Disambiguation</a> 
-	    </li>-->
+<li>
+	<a href="exp6/Introduction.html?domain=Computer Science&lab=Computational Linguistics Lab">Word Sense Disambiguation</a> 
+</li>
 <li>
 <a href="exp7/Introduction.html?domain=Computer Science&lab=Computational Linguistics Lab">Coarse-grained POS Tagging</a>
 </li>

--- a/src/lab/exp8/Further Readings.html
+++ b/src/lab/exp8/Further Readings.html
@@ -99,7 +99,7 @@
 							
 							<!--edit -->
 <h1 class="text-h2-lightblue">Fine - grained POS Tagging</h1><div class="content" id="experiment-article-section-7-content">
-<center>http://www.comp.leeds.ac.uk/ccalas/tagsets/upenn.html<br/></center>
+<center>https://www.ling.upenn.edu/courses/Fall_2003/ling001/penn_treebank_pos.html<br/></center>
 <center>The University of Pennsylvania (Penn) Treebank Tag-set</center> <br/>
 <center>http://ltrc.iiit.ac.in/MachineTrans/publications/technicalReports/tr031/posguidelines.pdf</center>
 <center>AnnCorra : Guidelines For POS And Chunk Annotation For Indian Languages - Akshar Bharati, Dipti Misra Sharma, Lakshmi Bai, Rajeev Sangal</center>


### PR DESCRIPTION
#48  and #61  fixed. 

- #48 by finding an alter as described. (New and active Treebank link)

- #61 by Googling up the location of the lost exp6 and decommenting it out of Index source code.